### PR TITLE
Fix missing var $debugMode

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,5 @@
 <?php
+$debugMode = (bool) \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class)->getVar('iDebug');
 if (class_exists('\ProudSourcing\ExceptionHandler\Core\Exception\ExceptionHandler')) {
     set_exception_handler(
         [
@@ -7,3 +8,4 @@ if (class_exists('\ProudSourcing\ExceptionHandler\Core\Exception\ExceptionHandle
         ]
     );
 }
+unset($debugMode);


### PR DESCRIPTION
`$debugMode` is missing, which causes a `PHP Notice:  Undefined variable: debugMode`.
Using the same approach as in https://github.com/OXID-eSales/oxideshop_ce/blob/2f9d687214b230eb5ec4bd15b5fa406185fbfbab/source/bootstrap.php#L164